### PR TITLE
Fix link to P4Runtime blog

### DIFF
--- a/_posts/2017-07-20-announcing-p4runtime-a-contribution-by-the-p4-api-working-group.html
+++ b/_posts/2017-07-20-announcing-p4runtime-a-contribution-by-the-p4-api-working-group.html
@@ -4,6 +4,7 @@ title: Announcing P4Runtime - A contribution by the P4 API Working Group
 date: 2017-07-20
 author: P4.org
 category: api
+redirect_from: /api/api/announcing-p4runtime-a-contribution-by-the-p4-api-working-group/
 header-img: assets/p4-background.png
 ---
 <p><em>by Lorenzo Vicisano &amp; Antonin Bas</em></p>


### PR DESCRIPTION
Add `redirect_from` with URL from old website.