### PR TITLE
Learning P4 Page

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -22,6 +22,7 @@
         <li><a href="{{ site.baseurl }}/events">Events</a></li>
         <li><a href="{{ site.baseurl }}/specs">Specifications</a></li>
         <li><a href="{{ site.baseurl }}/code">Code</a></li>
+        <li><a href="{{ site.baseurl }}/learn">Learn</a></li>
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" id="dd-community" data-toggle="dropdown">Community<span class="caret"></span></a>
           <ul class="dropdown-menu">

--- a/_pages/learn.html
+++ b/_pages/learn.html
@@ -1,0 +1,67 @@
+---
+layout: post
+title: Learning
+description: "Learning P4"
+permalink: learn/
+header-img: assets/p4-background.png
+---
+
+<h1 id="gettingstarted">Getting Started With P4</h1>
+
+<p><strong>What</strong> is P4?</p>
+<ul>
+<li>P4 is a programming language to describe packet processing. It is commonly used to specify how network devices, such as switches and routers, should process packets in the data plane.</li>
+</ul>
+
+<p><strong>Who</strong> should learn P4?</p>
+<ul>
+<li>Network device manufacturers</li>
+<li>Network operators</li>
+<li>Researchers interested in: new network applications, switch design, programming languages</li>
+<li>Teachers / students that would like to teach / learn about the fundamentals of computer networking while obtaining hands-on experience</li>
+</ul>
+
+<p><strong>Why</strong> should I learn P4?</p>
+<ul>
+<li>P4 is becoming widely adopted as the de facto standard for describing the packet processing functionality of network devices. As its adoption continues to grow in both industry and academia, it will become more and more important to understand how to read and write P4 programs.</li>
+</ul>
+
+<p><strong>Where</strong> can I learn P4?</p>
+<ul>
+<li>The rest of this page will walk through some hands-on tutorial exercises using open source software that is free to download.</li>
+</ul>
+
+<p><strong>When</strong> should I learn P4?</p>
+<ul>
+<li>Now!</li>
+</ul>
+
+<h1 id="handsontutorials">Hands-on Tutorials</h1>
+<p>We've put together some introductory material to help you get started learning P4. Please visit <a href="https://github.com/p4lang/tutorials/tree/master/P4D2_2017_Fall/exercises#obtaining-required-software">here</a> for instructions to set up the environment that we will use for the tutorial assignments.</p>
+
+<h2 id="intro">Introduction to P4</h2>
+<p>The video below provides an overview of data plane programming and introduces the approach taken by the P4 programming language.</p>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/4w-jEr99pBE?rel=0" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>
+
+<h2 id="p4basics">P4 Basics / Exercise 1 - Basic IP Routing</h2>
+<p>The following two videos provide an overview of the P4 programming language and walk through the first programming exercise: building a basic IP router. </p>
+
+<p><strong>Part I</strong></p>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/cvDtVobw9wE?rel=0" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>
+
+<p><strong>Part II</strong></p>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/6LXtneLfAPI?rel=0" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>
+
+<h2 id="basictunneling">Exercise 2 - Basic Tunneling</h2>
+<p>The following video will walk through the second programming exercise which builds off of the basic IP router to add support for a custom tunneling protocol.</p>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/KlEi87XYMBE?rel=0" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>
+
+<h2 id="moreexercises">More Exercises</h2>
+<p>If you would like some more hands-on experience with P4 please see the <a href="https://github.com/p4lang/tutorials/tree/master/P4D2_2017_Fall/exercises#p4-tutorial">P4 tutorials</a> github repository, which will walk you through more tutorial exercises.</p>
+
+<h1 id="additionalresources">Additional Resources</h1>
+<ul>
+<li><a href="https://p4.org/p4/clarifying-the-differences-between-p4-and-openflow.html">Blog post</a> explaining the differences between P4 and OpenFlow.</li>
+<li><a href="https://p4.org/api/p4-runtime-putting-the-control-plane-in-charge-of-the-forwarding-plane.html">P4Runtime Blog Post</a></li>
+</ul>
+


### PR DESCRIPTION
Added initial draft of a "Learning P4" page. 

A couple of notes:

- Currently, the videos are uploaded to my personal account. Not sure if it would be better to upload them to the P4 youtube channel and link to those instead.

- We should probably upload them to youku as well and show those instead if the client is in China.

- I removed the FAQ section that I had initially because I saw that there is already an FAQ page. I'd like to add a link to that page once it is available.

- I'd also like to add a link to the slides, but I can't find them on Google Drive anymore. Have they been moved since the P4 Developer Day?