### PR TITLE
Update links for P4Runtime spec

### DIFF
--- a/_pages/specs.html
+++ b/_pages/specs.html
@@ -56,7 +56,17 @@ header-img: assets/p4-background.png
   <div class="row">
     <div class="col-lg-5 col-md-5">
       <h3>P4Runtime</h3>
-      <p>P4Runtime v1.0.0, working draft: [<a href="https://p4lang.github.io/p4-spec/docs/P4Runtime-v1.0.0.pdf">PDF</a>]</p>
+      <p>Releases for P4Runtime
+        <ul>
+          <li>v1.0.0-rc2
+            [<a href="https://s3-us-west-2.amazonaws.com/p4runtime/docs/v1.0.0-rc2/P4Runtime-Spec.html">HTML</a> |
+            <a href="https://s3-us-west-2.amazonaws.com/p4runtime/docs/v1.0.0-rc2/P4Runtime-Spec.pdf">PDF</a>] (Aug 2018)</li>
+          <li>v1.0.0 <i>working draft</i>:
+            [<a href="https://s3-us-west-2.amazonaws.com/p4runtime/docs/master/P4Runtime-Spec.html">HTML</a> |
+            <a href="https://s3-us-west-2.amazonaws.com/p4runtime/docs/master/P4Runtime-Spec.pdf">PDF</a>]
+          </li>
+        </ul>
+      </p>
     </div>
     <div class="col-lg-2 col-md-2">
     </div>


### PR DESCRIPTION
The generated specification documents are now automatically uploaded to
AWS S3 by Travis. We update the links under specs/ now that we have
released P4Runtime v1.0.0-rc2.