### PR TITLE
Small changes to instructions for NANOG

### DIFF
--- a/_events/2019-02-19-nanog.md
+++ b/_events/2019-02-19-nanog.md
@@ -4,7 +4,7 @@ title: P4 Tutorial at NANOG 75
 date: 2019-02-19
 header-img: assets/p4-background.png
 ---
-        
+
 ### A presentation by the P4 Education Working Group at [NANOG 75](https://www.nanog.org).
 
 
@@ -19,33 +19,31 @@ header-img: assets/p4-background.png
 * Antonin Bas (Barefoot Networks)
 
 
-### Software 
+### Software
 
-We have created a Docker image that has all of the software needed to complete the tutorial exercises already installed. 
+We have created a Docker image that has all of the software needed to complete the tutorial exercises already installed.
 
 * To download the Docker image:
-    1. Install Docker  
-       [https://www.docker.com](https://www.docker.com)
-       
-       You may also find the instructions on the following links useful:
-		- [ubuntu 16.04](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-16-04)
-		- [ubutnu 18.04](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-18-04)
-		- [Mac (dockerhub account required)](https://hub.docker.com/editions/community/docker-ce-desktop-mac)
-		- [Windows (dockerhub account required)](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
-       
+    1. Install Docker
 
+       [https://www.docker.com](https://www.docker.com)
+
+       You may also find the instructions at the following links useful:
+
+         * [Ubuntu 16.04](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-16-04)
+         * [Ubuntu 18.04](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-18-04)
+         * [Mac (dockerhub account required)](https://hub.docker.com/editions/community/docker-ce-desktop-mac)
+
+       ***When installing on Ubuntu, make sure you do the optional step 2 ("Executing the Docker Command Without Sudo").***
 
     1. Clone the p4app repository:
-    
+
        `git clone --branch p4app --recurse-submodules https://github.com/p4lang/tutorials`
 
     1. Change directory to the first exercise:
 
        `cd tutorials/p4app-exercises/basic.p4app`
-       
-    1. Try running the first example. This will download the docker image and store it locally, so you will have it ready for the event. You should see a mininet prompt ("mininet>") at the end:
+
+    1. Try running the first example. This will download the docker image and store it locally, so you will have it ready for the event. You should see a mininet prompt (`mininet>`) at the end:
 
        `make run`
-
-
-    


### PR DESCRIPTION
When installing docker on Ubuntu, make sure you can run docker without
sudo, it is required by p4app.

Also removed link to Windows instructions, as I'm pretty sure p4app
won't work on Windows out of the box.