### PR TITLE
news: Fix broken link

### DIFF
--- a/_includes/news.html
+++ b/_includes/news.html
@@ -6,12 +6,12 @@
   <li>Blog post on <a href="{{ site.baseurl }}/members/netcope-member-spotlight">Netcope Member Spotlight</a> published.
   <li>Blog post on <a href="{{ site.baseurl }}/members/xilinx-member-spotlight">Xilinx Member Spotlight</a> published.
   <li><a href="{{ site.baseurl }}/events/2018-08-20-tutorial/">P4 SIGCOMM Tutorial</a> announced.
-  <li>Blog post on <a href="{{ site.baseurl }}/p4/netcache-balancing-key-value-stores-with-fast-in-network-caching.html/">NetCache</a> published.
+  <li>Blog post on <a href="{{ site.baseurl }}/p4/netcache-balancing-key-value-stores-with-fast-in-network-caching.html">NetCache</a> published.
   <li><a href="{{ site.baseurl }}/events/2018-09-24-p4-eu-workshop/">P4 Workshop in Europe</a> announced.
   <li>Blog post on <a href="{{ site.baseurl }}/p4/advancing-disaggregation-through-p4-runtime-integration.html">Juniper AFI</a>, which is based on P4 Runtime.
   <li><a href="{{ site.baseurl }}/events/2018-06-05-p4-workshop/">5th P4 Workshop</a> and <a href="{{ site.baseurl }}/events/2018-06-06-p4-developer-day/">Spring Developer Day</a> announced.
   <li><a href="{{ site.baseurl }}/p4/p4-joins-onf-and-lf.html">P4 joins ONF and LF</a> (March 2018)</li>
-  <li><a href="{{ site.baseurl }}/p4-spec/docs/PSA.html">PSA Specification</a> Released (February 2018) </li>  
+  <li><a href="{{ site.baseurl }}/p4-spec/docs/PSA.html">PSA Specification</a> Released (February 2018) </li>
   <li><a href="{{ site.baseurl }}/events/2018-03-09-p4-developer-day">East Coast Developer Day</a> at Cornell Tech announced! (January 2018)</li>
   <li>New <a href="{{ site.baseurl }}">P4 Website</a> launched! (December 2017)</li>
 </ul>


### PR DESCRIPTION
The link for the [NetCache: Balancing Key-Value Stores with Fast In-Network Caching](https://p4.org/p4/netcache-balancing-key-value-stores-with-fast-in-network-caching.html) page has a trailing slash results in a `404 File not found` message.