### PR TITLE
Europ4 2020: (hopefully) the final update

### DIFF
--- a/_events/2020-12-01-euro-p4-workshop.md
+++ b/_events/2020-12-01-euro-p4-workshop.md
@@ -46,19 +46,19 @@ It aims to bring together P4 and P4->NetFPGA researchers from Europe and from ar
     *Session Chair:* Noa Zilberman, *University of Oxford*
 
     * __11:00 - 11:15, GMT__  
-    *Comparative Evaluation of IP-Address Anti-Spoofing Mechanisms using a P4/NetFPGA-based Switch.* ([Paper](https://drive.google.com/file/d/1NOsKZrtYPlwn7vhJHM5HFCIHkgIqlBku/view?usp=sharing))  
+    *Comparative Evaluation of IP-Address Anti-Spoofing Mechanisms using a P4/NetFPGA-based Switch.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431320), [Video](https://dl.acm.org/doi/10.1145/3426744.3431320#sec-supp))  
     Harsh Gondaliya (SRM Institute of Science and Technology), Ganesh C. Sankaran (University of California, Davis), Krishna Sivalingam (Indian Institute of Technology Madras)
 
     * __11:15 - 11:30, GMT__  
-    *Falcon - Low Latency, Network-Accelerated Scheduling.* ([Paper](https://drive.google.com/file/d/1hp7mu3kepF7XoL2yYPanwTzDSdM1CthV/view?usp=sharing))  
+    *Falcon - Low Latency, Network-Accelerated Scheduling.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431322), [Video](https://dl.acm.org/doi/10.1145/3426744.3431322#sec-supp))  
     Ibrahim Kettaneh (University of Waterloo), Sreeharsha Udayashankar (University of Waterloo), Ashraf Abdel-hadi (University of Waterloo), Samer Al-Kiswany (University of Waterloo)
 
     * __11:30 - 11:45, GMT__  
-    *SYN Flood Defense in Programmable Data Planes.* ([Paper](https://drive.google.com/file/d/1aWWFvvseWzUrsZk1XEAhQKYup4LV5vCa/view?usp=sharing))  
+    *SYN Flood Defense in Programmable Data Planes.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431323), [Video](https://dl.acm.org/doi/10.1145/3426744.3431323#sec-supp))  
     Dominik Scholz (Technical University of Munich), Sebastian Gallenmüller (Technical University of Munich), Henning Stubbe (Technical University of Munich), Georg Carle (Technical University of Munich)
 
     * __11:45 - 12:00, GMT__  
-    *P4-Protect: 1+1 Path Protection for P4.* ([Paper](https://drive.google.com/file/d/1z8C2712CUhfSVSQRM_xMiqMzawRqawdK/view?usp=sharing))  
+    *P4-Protect: 1+1 Path Protection for P4.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431327), [Video](https://dl.acm.org/doi/10.1145/3426744.3431327#sec-supp))  
     Steffen Lindner (University of Tuebingen), Daniel Merling (University of Tuebingen), Marco Häberle (University of Tuebingen), Michael Menth (University of Tuebingen)
 
     * __12:00 - 12:30, GMT__  
@@ -80,29 +80,29 @@ It aims to bring together P4 and P4->NetFPGA researchers from Europe and from ar
     * Posters
 
         * __13:30 - 13:40, GMT__  
-        *Unleashing the performance of virtual BNG by offloading data plane to a programmable ASIC.* ([Paper](https://drive.google.com/file/d/1ox9JW9NgDfueVqgegJvmDGUh9j9ONwrb/view?usp=sharing))  
+        *Unleashing the performance of virtual BNG by offloading data plane to a programmable ASIC.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431325), [Video](https://dl.acm.org/doi/10.1145/3426744.3431325#sec-supp))  
         Tomasz Osiński (Orange Labs & Warsaw University of Technology), Mateusz Kossakowski (Orange Labs), Mateusz Pawlik (Orange Labs), Jan Palimąka (Orange Labs), Michał Sala (Orange Labs), Halina Tarasiuk (Warsaw University of Technology)
 
         * __13:40 - 13:50, GMT__  
-        *Towards a Hybrid Next Generation NodeB.* ([Paper](https://drive.google.com/file/d/11dcOvdN0fvVJ6kD05F9is0Ht9uj3Nwi3/view?usp=sharing))  
+        *Towards a Hybrid Next Generation NodeB.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431328), [Video](https://dl.acm.org/doi/10.1145/3426744.3431328#sec-supp))  
         Péter Vörös (Eötvös Loránd University), Gergely Pongrácz (Ericsson Research), Sándor Laki (Eötvös Loránd University)
 
         * __13:50 - 14:00, GMT__  
-        *A perspective on P4-based data and control plane modularity for network automation.* ([Paper](https://drive.google.com/file/d/1IjDqpdUgFc-k1u8nwz8BLy_wcsprtstw/view?usp=sharing))  
+        *A perspective on P4-based data and control plane modularity for network automation.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431330), [Video](https://dl.acm.org/doi/10.1145/3426744.3431330#sec-supp))  
         Eder Ollora Zaballa (Technical University of Denmark), David Franco (University of the Basque Country), Michael Stübert Berger (Denmark Techinical University), Mariavi Higuero (University of the Basque Country)
 
     * Demos
 
         * __14:00 - 14:10, GMT__  
-        *A P4 Data Plane for the Quantum Internet.* ([Paper](https://drive.google.com/file/d/15XuqsvAE4Lu_w84BOr-qHK9D4mCwjIA9/view?usp=sharing))  
+        *A P4 Data Plane for the Quantum Internet.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431321), [Video](https://dl.acm.org/doi/10.1145/3426744.3431321#sec-supp))  
         Wojciech Kozlowski (QuTech, Delft University of Technology), Fernando Kuipers (Delft University of Technology), Stephanie Wehner (QuTech, Delft University of Technology)
 
         * __14:10 - 14:20, GMT__  
-        *Developing EFSM-based stateful applications with FlowBlaze.p4 and ONOS.* ([Paper](https://drive.google.com/file/d/1Rrw0UcKbGn7TRq8L_H3UpStU_1MqE6T-/view?usp=sharing))  
+        *Developing EFSM-based stateful applications with FlowBlaze.p4 and ONOS.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431324), [Video](https://dl.acm.org/doi/10.1145/3426744.3431324#sec-supp))  
         Daniele Moro (Politecnico di Milano), Davide Sanvito (NEC Laboratories Europe), Antonio Capone (Politecnico di Milano)
 
         * __14:20 - 14:30, GMT__  
-        *Pushing Network Programmability to the Limits with SRv6 uSID and P4.* ([Paper](https://drive.google.com/file/d/1ZgYxeR2jQf1dEss2N0UMQALGdhnN45F6/view?usp=sharing))  
+        *Pushing Network Programmability to the Limits with SRv6 uSID and P4.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431331), [Video](https://dl.acm.org/doi/10.1145/3426744.3431331#sec-supp))  
         Ahmed Abdelsalam (Cisco Systems), Angelo Tulumello (University of Rome Tor Vergata), Marco Bonola (CNIT – National Inter University Consortium for Telecommunications), Stefano Salsano (University of Rome Tor Vergata), Clarence Filsfils (Cisco Systems)
 
 ---
@@ -119,15 +119,15 @@ It aims to bring together P4 and P4->NetFPGA researchers from Europe and from ar
     *Session Chair:* Robert Soulé, *Yale University*
 
     * __15:00 - 15:15, GMT__  
-    *Compiling Packet Programs to Reconfigurable Switches: Theory and Algorithms.* ([Paper](https://drive.google.com/file/d/1Rp4JZ9zrestKGKBgKbWJxGMEUkMs-M6-/view?usp=sharing))  
+    *Compiling Packet Programs to Reconfigurable Switches: Theory and Algorithms.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431332), [Video](https://dl.acm.org/doi/10.1145/3426744.3431332#sec-supp))  
     Balázs Vass (Budapest University of Technology and Economics), Erika Bérczi-Kovács (Eötvös Loránd Science University), Costin Raiciu (University Politehnica of Bucharest), Gábor Rétvári (Budapest University of Technology and Economics)
 
     * __15:15 - 15:30, GMT__  
-    *Leveraging P4 Flexibility to Expose Target-specific Features.* ([Paper](https://drive.google.com/file/d/125TzyRnmxHLuNa321lHof_9ZNZSvAQ66/view?usp=sharing))  
+    *Leveraging P4 Flexibility to Expose Target-specific Features.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431326), [Video](https://dl.acm.org/doi/10.1145/3426744.3431326#sec-supp))  
     Alex Seibulescu (Pensando Systems, Inc.), Mario Baldi (Pensando Systems, Inc.)
 
     * __15:30 - 15:45, GMT__  
-    *MTPSA: Multi-Tenant Programmable Switches.* ([Paper](https://drive.google.com/file/d/1WCm3TiSsQndUCvNwx5QRE6ZJfhoKHQRA/view?usp=sharing))  
+    *MTPSA: Multi-Tenant Programmable Switches.* ([Paper](https://dl.acm.org/doi/10.1145/3426744.3431329), [Video](https://dl.acm.org/doi/10.1145/3426744.3431329#sec-supp))  
     Radostin Stoyanov (University of Cambridge), Noa Zilberman (University of Oxford)
 
     * __15:45 - 16:15, GMT__  

--- a/_events/2020-12-01-euro-p4-workshop.md
+++ b/_events/2020-12-01-euro-p4-workshop.md
@@ -174,8 +174,10 @@ As a consequence of the current situation of the COVID-19 pandemic and similar t
 
 ### Organizing Committee
 
-Salvatore Signorello, *University of Lisbon*  
-Tamás Lévai, *Budapest University of Technology and Economics*  
+Hotcrp Chair: Salvatore Signorello, *University of Lisbon*  
+Publicity Chair: Tamás Lévai, *Budapest University of Technology and Economics*  
+Slack Chair: João Amado, *University of Lisbon*  
+Mozilla Hub Chair: Gonçalo Matos, *University of Lisbon*  
 
 ### Technical Program Committee
 

--- a/_events/2020-12-01-euro-p4-workshop.md
+++ b/_events/2020-12-01-euro-p4-workshop.md
@@ -155,12 +155,12 @@ It aims to bring together P4 and P4->NetFPGA researchers from Europe and from ar
 ~~*Camera ready:* Thursday, October 29th, 2020 (11:59PM AoE)~~  
 ~~*Video upload:* Wednesday, November 18th, 2020 (11:59PM AoE)~~  
 
-### Participation
+<!-- ### Participation -->
 
-As a consequence of the current situation of the COVID-19 pandemic and similar to CoNEXT'20, EuroP4'20 will be a fully virtual (online) event. Please follow the updates on the CoNEXT'20 and our website for the details.
+<!-- As a consequence of the current situation of the COVID-19 pandemic and similar to CoNEXT'20, EuroP4'20 will be a fully virtual (online) event. Please follow the updates on the CoNEXT'20 and our website for the details. -->
 
-### Registration
-[Registration is through CoNEXT 2020](https://conferences2.sigcomm.org/co-next/2020/)
+<!-- ### Registration -->
+<!-- [Registration is through CoNEXT 2020](https://conferences2.sigcomm.org/co-next/2020/) -->
 
 ### General Chairs
 


### PR DESCRIPTION
Added the ACM DL paper+video links, we are promised these should work from now on to eternity
Marked Gonçalo and João as slack and mozilla hub chairs
Removed text on registration and participation