### PR TITLE
Update P4Runtime spec links from "master" to "main"

### DIFF
--- a/_pages/specs.html
+++ b/_pages/specs.html
@@ -35,8 +35,8 @@ header-img: assets/p4-background.png
             [<a href="https://p4.org/p4runtime/spec/v1.3.0/P4Runtime-Spec.html">HTML</a> |
             <a href="https://p4.org/p4runtime/spec/v1.3.0/P4Runtime-Spec.pdf">PDF</a>] (Dec 2020)</li>
           <li><i>Working draft</i>:
-            [<a href="https://p4.org/p4runtime/spec/master/P4Runtime-Spec.html">HTML</a> |
-            <a href="https://p4.org/p4runtime/spec/master/P4Runtime-Spec.pdf">PDF</a>]
+            [<a href="https://p4.org/p4runtime/spec/main/P4Runtime-Spec.html">HTML</a> |
+            <a href="https://p4.org/p4runtime/spec/main/P4Runtime-Spec.pdf">PDF</a>]
           </li>
         </ul>
       </p>


### PR DESCRIPTION
To refelect the renaming of the default branch in the p4lang/p4runtime
repository.